### PR TITLE
Fix MPC cost function

### DIFF
--- a/src/LinearMPCOverNetworks/RegulatorMPC.py
+++ b/src/LinearMPCOverNetworks/RegulatorMPC.py
@@ -63,7 +63,7 @@ class RegulatorMPC:
         constraints=[self._x_mpc[:,0]==self._x_init_param]
         cost = 0
         for i in range(self._N):
-            cost += cp.quad_form(self._x_mpc[:,i+1],self._Q)+cp.quad_form(self._u_mpc[:,i],self._R)
+            cost += cp.quad_form(self._x_mpc[:,i],self._Q)+cp.quad_form(self._u_mpc[:,i],self._R)
             
             # dynamic constraint x(k+1)=Ax(k)+Bu(k)
             constraints += [self._x_mpc[:,i+1]==self._A @ self._x_mpc[:,i] + self._B @ self._u_mpc[:,i]]

--- a/src/LinearMPCOverNetworks/TrackingMPC.py
+++ b/src/LinearMPCOverNetworks/TrackingMPC.py
@@ -87,7 +87,7 @@ class TrackingMPC(RegulatorMPC.RegulatorMPC):
         constraints=[self._x_mpc[:,0]==self._x_init_param]
         cost = 0
         for i in range(self._N):
-            cost += cp.quad_form(self._x_mpc[:,i+1]-self._x_bar,self._Q)+cp.quad_form(self._u_mpc[:,i]-self._u_bar,self._R)
+            cost += cp.quad_form(self._x_mpc[:,i]-self._x_bar,self._Q)+cp.quad_form(self._u_mpc[:,i]-self._u_bar,self._R)
             # dynamic constraint x(k+1)=Ax(k)+Bu(k)
             constraints += [self._x_mpc[:,i+1]==self._A @ self._x_mpc[:,i] + self._B @ self._u_mpc[:,i]]
             if self._X is not None:

--- a/src/LinearMPCOverNetworks/TubeRegulatorMPC.py
+++ b/src/LinearMPCOverNetworks/TubeRegulatorMPC.py
@@ -129,7 +129,7 @@ class TubeRegulatorMPC(RegulatorMPC):
         cost = 0
 
         for i in range(self._N):
-            cost += cp.quad_form(self._x_mpc[:,i+1],self._Q)+cp.quad_form(self._u_mpc[:,i],self._R)
+            cost += cp.quad_form(self._x_mpc[:,i],self._Q)+cp.quad_form(self._u_mpc[:,i],self._R)
             # dynamic constraint x(k+1)=Ax(k)+Bu(k)
             constraints += [self._x_mpc[:,i+1]==self._A @ self._x_mpc[:,i] + self._B @ self._u_mpc[:,i]] 
             constraints += [Hx@self._x_mpc[:,i]<=hx] # state constraint x(k)\in X

--- a/src/LinearMPCOverNetworks/TubeTrackingMPC.py
+++ b/src/LinearMPCOverNetworks/TubeTrackingMPC.py
@@ -133,7 +133,7 @@ class TubeTrackingMPC(TubeRegulatorMPC):
         cost = 0
 
         for i in range(self._N):
-            cost += cp.quad_form(self._x_mpc[:,i+1]-self._x_bar,self._Q)+cp.quad_form(self._u_mpc[:,i]-self._u_bar,self._R)
+            cost += cp.quad_form(self._x_mpc[:,i]-self._x_bar,self._Q)+cp.quad_form(self._u_mpc[:,i]-self._u_bar,self._R)
             # dynamic constraint x(k+1)=Ax(k)+Bu(k)
             constraints += [self._x_mpc[:,i+1]==self._A @ self._x_mpc[:,i] + self._B @ self._u_mpc[:,i]] # dynamics constraint
             constraints += [Hx@self._x_mpc[:,i]<=hx] # state constraint x(k)\in X
@@ -280,7 +280,7 @@ class ExtendedTubeTrackingMPC(TubeTrackingMPC):
         cost = 0
 
         for i in range(self._N):
-            cost += cp.quad_form(self._x_mpc_packet_received[:,i+1]-self._x_bar_packet_received,self._Q)+cp.quad_form(self._u_mpc_packet_received[:,i]-self._u_bar_packet_received,self._R)
+            cost += cp.quad_form(self._x_mpc_packet_received[:,i]-self._x_bar_packet_received,self._Q)+cp.quad_form(self._u_mpc_packet_received[:,i]-self._u_bar_packet_received,self._R)
             constraints += [self._x_mpc_packet_received[:,i+1]==self._A @ self._x_mpc_packet_received[:,i] + self._B @ self._u_mpc_packet_received[:,i]] # dynamics constraint
             constraints += [Hx@self._x_mpc_packet_received[:,i]<=hx] # state constraint
             constraints += [Hu@self._u_mpc_packet_received[:,i]<=hu] # output constraint


### PR DESCRIPTION
This PR fixes typos on the formulation of the cost functions of a few MPC in the repo, in which we mistakenly used "i+1" instead of "i".